### PR TITLE
Export localization function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import type { Moment } from "moment";
+import type { Locale, Moment } from "moment";
 import { SvelteComponentTyped } from "svelte";
 
 export type ILocaleOverride = "system-default" | string;
@@ -32,10 +32,7 @@ export interface ICalendarSource {
 export class Calendar extends SvelteComponentTyped<{
   // Settings
   showWeekNums: boolean;
-
-  // Localization
-  localeOverride: ILocaleOverride;
-  weekStart: IWeekStartOption;
+  localeData?: Locale;
 
   // Event Handlers
   onHoverDay?: (date: Moment, targetEl: EventTarget) => void;
@@ -53,3 +50,8 @@ export class Calendar extends SvelteComponentTyped<{
   today?: Moment;
   displayedMonth?: Moment;
 }> {}
+
+export function configureGlobalMomentLocale(
+  localeOverride: ILocaleOverride,
+  weekStart: IWeekStartOption
+): string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-calendar-ui",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Calendar UI that powers obsidian-calendar-plugin",
   "author": "liamcain",
   "main": "dist/index.js",

--- a/src/components/Calendar.svelte
+++ b/src/components/Calendar.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable />
 
 <script lang="ts">
-  import type { Moment } from "moment";
+  import type { Locale, Moment } from "moment";
 
   import Day from "./Day.svelte";
   import Nav from "./Nav.svelte";
@@ -9,11 +9,9 @@
   import { getDailyMetadata, getWeeklyMetadata } from "../metadata";
   import type { ICalendarSource, IMonth } from "../types";
   import { getDaysOfWeek, getMonth, isWeekend } from "../utils";
-  import type { ILocaleOverride, IWeekStartOption } from "../localization";
 
   // Localization
-  export let weekStart: IWeekStartOption = "locale";
-  export let localeOverride: ILocaleOverride;
+  export let localeData: Locale;
 
   // Settings
   export let showWeekNums: boolean = false;
@@ -45,8 +43,8 @@
   let month: IMonth;
   let daysOfWeek: string[];
 
-  $: month = getMonth(displayedMonth, weekStart, localeOverride);
-  $: daysOfWeek = getDaysOfWeek(today, localeOverride);
+  $: month = getMonth(displayedMonth, localeData);
+  $: daysOfWeek = getDaysOfWeek(today, localeData);
 
   // Exports
   export function incrementDisplayedMonth() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
+import type moment from "moment";
+import type { App } from "obsidian";
+
 import Calendar from "./components/Calendar.svelte";
 import type { ICalendarSource, IDot, IDayMetadata } from "./types";
-import type { App } from "obsidian";
-import type moment from "moment";
 
 declare global {
   interface Window {
@@ -12,3 +13,4 @@ declare global {
 
 export { Calendar };
 export type { ICalendarSource, IDot, IDayMetadata };
+export { configureGlobalMomentLocale } from "./localization";

--- a/src/localization.ts
+++ b/src/localization.ts
@@ -52,36 +52,7 @@ const weekdays = [
   "saturday",
 ];
 
-/**
- * Sets the locale used by the calendar. This allows the calendar to
- * default to the user's locale (e.g. Start Week on Sunday/Monday/Friday)
- *
- * @param localeOverride locale string (e.g. "en-US")
- */
-export function configureMomentLocale(
-  localeOverride: ILocaleOverride = "system-default"
-): string {
-  const obsidianLang = localStorage.getItem("language") || "en";
-  const systemLang = navigator.language?.toLowerCase();
-
-  let momentLocale = langToMomentLocale[obsidianLang];
-
-  if (localeOverride !== "system-default") {
-    momentLocale = localeOverride;
-  } else if (systemLang.startsWith(obsidianLang)) {
-    // If the system locale is more specific (en-gb vs en), use the system locale.
-    momentLocale = systemLang;
-  }
-
-  const currentLocale = window.moment.locale(momentLocale);
-  console.debug(
-    `[Calendar] Trying to switch Moment.js global locale to ${momentLocale}, got ${currentLocale}`
-  );
-
-  return currentLocale;
-}
-
-export function overrideMomentWeekStart(weekStart: IWeekStartOption): void {
+function overrideGlobalMomentWeekStart(weekStart: IWeekStartOption): void {
   const { moment } = window;
   const currentLocale = moment.locale();
 
@@ -103,4 +74,36 @@ export function overrideMomentWeekStart(weekStart: IWeekStartOption): void {
       },
     });
   }
+}
+
+/**
+ * Sets the locale used by the calendar. This allows the calendar to
+ * default to the user's locale (e.g. Start Week on Sunday/Monday/Friday)
+ *
+ * @param localeOverride locale string (e.g. "en-US")
+ */
+export function configureGlobalMomentLocale(
+  localeOverride: ILocaleOverride = "system-default",
+  weekStart: IWeekStartOption = "locale"
+): string {
+  const obsidianLang = localStorage.getItem("language") || "en";
+  const systemLang = navigator.language?.toLowerCase();
+
+  let momentLocale = langToMomentLocale[obsidianLang];
+
+  if (localeOverride !== "system-default") {
+    momentLocale = localeOverride;
+  } else if (systemLang.startsWith(obsidianLang)) {
+    // If the system locale is more specific (en-gb vs en), use the system locale.
+    momentLocale = systemLang;
+  }
+
+  const currentLocale = window.moment.locale(momentLocale);
+  console.debug(
+    `[Calendar] Trying to switch Moment.js global locale to ${momentLocale}, got ${currentLocale}`
+  );
+
+  overrideGlobalMomentWeekStart(weekStart);
+
+  return currentLocale;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,6 @@
 import type { Moment } from "moment";
 import * as os from "os";
 
-import {
-  configureMomentLocale,
-  overrideMomentWeekStart,
-  ILocaleOverride,
-  IWeekStartOption,
-} from "./localization";
 import type { IMonth, IWeek } from "./types";
 
 function isMacOS() {
@@ -33,17 +27,8 @@ export function getStartOfWeek(days: Moment[]): Moment {
  * Generate a 2D array of daily information to power
  * the calendar view.
  */
-export function getMonth(
-  displayedMonth: Moment,
-  weekStart: IWeekStartOption,
-  localeOverride?: ILocaleOverride
-): IMonth {
-  // These functions mutate the global window.moment object.
-  // Call them here to make sure the calendar view stays in
-  // sync with settings.
-  const locale = configureMomentLocale(localeOverride);
-  overrideMomentWeekStart(weekStart);
-
+export function getMonth(displayedMonth: Moment, ..._args: unknown[]): IMonth {
+  const locale = window.moment().locale();
   const month = [];
   let week: IWeek;
 


### PR DESCRIPTION
Export the localization function instead of calling it automatically. This fixes issues where the localization needs to happen earlier in the plugin initialization.