### PR TITLE
display today in bold

### DIFF
--- a/src/components/Day.svelte
+++ b/src/components/Day.svelte
@@ -155,6 +155,7 @@
 
   .today {
     color: var(--color-text-today);
+    font-weight: bold;
   }
 
   .day:active,


### PR DESCRIPTION
It can be very hard to see where is today on the calendar.

I'm turning it to bold so it can be quicker to find the current date, but also the same day next week, on the previous week, etc.