### PR TITLE
Support option to put week numbers on either side of calendar

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ export interface ICalendarSource {
 export class Calendar extends SvelteComponentTyped<{
   // Settings
   showWeekNums: boolean;
+  showWeekNumsRight: boolean;
   localeData?: Locale;
 
   // Event Handlers

--- a/src/components/Calendar.svelte
+++ b/src/components/Calendar.svelte
@@ -74,27 +74,33 @@
   />
   <table class="calendar">
     <colgroup>
-      {#if showWeekNums}
+      {#if showWeekNums && !showWeekNumsRight}
         <col />
       {/if}
       {#each month[1].days as date}
         <col class:weekend="{isWeekend(date)}" />
       {/each}
+      {#if showWeekNums && showWeekNumsRight}
+        <col />
+      {/if}
     </colgroup>
     <thead>
       <tr>
-        {#if showWeekNums}
+        {#if showWeekNums && !showWeekNumsRight}
           <th>W</th>
         {/if}
         {#each daysOfWeek as dayOfWeek}
           <th>{dayOfWeek}</th>
         {/each}
+        {#if showWeekNums && showWeekNumsRight}
+          <th>W</th>
+        {/if}
       </tr>
     </thead>
     <tbody>
       {#each month as week (week.weekNum)}
         <tr>
-          {#if showWeekNums}
+          {#if showWeekNums && !showWeekNumsRight}
             <WeekNum
               {...week}
               metadata="{getWeeklyMetadata(sources, week.days[0], today)}"
@@ -116,6 +122,16 @@
               selectedId="{selectedId}"
             />
           {/each}
+          {#if showWeekNums && showWeekNumsRight}
+            <WeekNum
+                {...week}
+                metadata="{getWeeklyMetadata(sources, week.days[0], today)}"
+                onClick="{onClickWeek}"
+                onContextMenu="{onContextMenuWeek}"
+                onHover="{onHoverWeek}"
+                selectedId="{selectedId}"
+            />
+          {/if}
         </tr>
       {/each}
     </tbody>

--- a/src/components/Calendar.svelte
+++ b/src/components/Calendar.svelte
@@ -15,6 +15,7 @@
 
   // Settings
   export let showWeekNums: boolean = false;
+  export let showWeekNumsRight: boolean = false;
 
   // Event Handlers
   export let onHoverDay: (

--- a/src/components/Calendar.svelte
+++ b/src/components/Calendar.svelte
@@ -108,6 +108,7 @@
               onContextMenu="{onContextMenuWeek}"
               onHover="{onHoverWeek}"
               selectedId="{selectedId}"
+              gridRight="{!showWeekNumsRight}"
             />
           {/if}
           {#each week.days as day (day.format())}
@@ -130,6 +131,7 @@
                 onContextMenu="{onContextMenuWeek}"
                 onHover="{onHoverWeek}"
                 selectedId="{selectedId}"
+                gridRight="{!showWeekNumsRight}"
             />
           {/if}
         </tr>

--- a/src/components/WeekNum.svelte
+++ b/src/components/WeekNum.svelte
@@ -13,6 +13,7 @@
   export let weekNum: number;
   export let days: Moment[];
   export let metadata: Promise<IDayMetadata> | null;
+  export let gridRight: boolean;
 
   // Event handlers
   export let onHover: (
@@ -30,7 +31,7 @@
   $: startOfWeek = getStartOfWeek(days);
 </script>
 
-<td>
+<td class="{gridRight ? 'grid-right' : 'grid-left'}">
   <MetadataResolver metadata="{metadata}" let:metadata>
     <div
       class="{`week-num ${metadata.classes.join(' ')}`}"
@@ -51,8 +52,11 @@
 </td>
 
 <style>
-  td {
+  td.grid-right {
     border-right: 1px solid var(--background-modifier-border);
+  }
+  td.grid-left {
+    border-left: 1px solid var(--background-modifier-border);
   }
 
   .week-num {

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,10 +607,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/codemirror@0.0.98":
-  version "0.0.98"
-  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.98.tgz#b35c7a4ab1fc1684b08a4e3eb65240020556ebfb"
-  integrity sha512-cbty5LPayy2vNSeuUdjNA9tggG+go5vAxmnLDRWpiZI5a+RDBi9dlozy4/jW/7P/gletbBWbQREEa7A81YxstA==
+"@types/codemirror@0.0.108":
+  version "0.0.108"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.108.tgz#e640422b666bf49251b384c390cdeb2362585bde"
+  integrity sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==
   dependencies:
     "@types/tern" "*"
 
@@ -3094,6 +3094,11 @@ moment@*, moment@2.29.1:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
+moment@2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3230,11 +3235,12 @@ obsidian-daily-notes-interface@0.8.4:
     obsidian obsidianmd/obsidian-api#master
     tslib "2.1.0"
 
-"obsidian@github:obsidianmd/obsidian-api#master":
-  version "0.11.7"
-  resolved "https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/55946e5a6259a28c416d2d6e600a7964a86a01dd"
+obsidian@obsidianmd/obsidian-api#master:
+  version "0.16.0"
+  resolved "https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/6b2138aa28fb6d6f58f78e6fabec02186fdc0f82"
   dependencies:
-    "@types/codemirror" "0.0.98"
+    "@types/codemirror" "0.0.108"
+    moment "2.29.4"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
The `<Calendar>` component accepts an additional boolean property that alternates week numbers between left and right side of the calendar. The border line separating the week numbers from the main calendar grid shifts position accordingly.

These changes are based on the most recent release of the UI package, https://github.com/liamcain/obsidian-calendar-ui/commit/03ceecbf6d88ef260dadf223ee5e483d98d24ffc.

This PR is meant to work with https://github.com/liamcain/obsidian-calendar-plugin/pull/266.