### PR TITLE
fixed weeknumber displayed on calendar to ISO Week number

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,7 @@ export function getMonth(displayedMonth: Moment, ..._args: unknown[]): IMonth {
     if (_day % 7 === 0) {
       week = {
         days: [],
-        weekNum: date.week(),
+        weekNum: date.isoWeek(),
       };
       month.push(week);
     }


### PR DESCRIPTION
I would recommend using the ISO standard for numbering the weeks of a year.  Because for example, for 2022 the plugin shows the wron weeknumber